### PR TITLE
Fix providerId handling in usage logging

### DIFF
--- a/convex/analytics.ts
+++ b/convex/analytics.ts
@@ -94,6 +94,12 @@ export const logUsage = mutation({
     vcuCost: v.number(),
   },
   handler: async (ctx, args) => {
+    // Only insert if we have a valid providerId
+    if (!args.providerId) {
+      console.warn("logUsage called without providerId, skipping log");
+      return;
+    }
+
     await ctx.db.insert("usageLogs", {
       address: args.address || 'anonymous',
       providerId: args.providerId,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -102,7 +102,7 @@ export default defineSchema({
 
   usageLogs: defineTable({
     address: v.string(),
-    providerId: v.id("providers"),
+    providerId: v.optional(v.id("providers")),
     model: v.string(),
     intent: v.string(),
     totalTokens: v.number(),


### PR DESCRIPTION
## Summary
- handle optional providerId in `logUsage` mutation
- make `providerId` optional in the `usageLogs` schema table

## Testing
- `npm run lint` *(fails: parameter implicit any errors)*
- `npm test` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b87c50a6c832f8e27ef847b07eca1