### PR TITLE
Fix analytics logging fields

### DIFF
--- a/convex/api.ts
+++ b/convex/api.ts
@@ -9,7 +9,15 @@ export type API = {
   };
   inference: {
     route: FunctionReference<"action", "public", { prompt: string; model?: string; walletAddress?: string; sessionId: string }, null, any>;
-    logUsage: FunctionReference<"mutation", "public", { address?: string; providerId: Id<"providers">; model: string; tokens: number; createdAt: number; latencyMs: number }, null, void>;
+    recordInference: FunctionReference<"mutation", "public", {
+      address: string;
+      providerId: Id<"providers">;
+      model: string;
+      intent: string;
+      totalTokens: number;
+      vcuCost: number;
+      timestamp: number;
+    }, null, null>;
     // ... other inference methods ...
   };
   wallets: {

--- a/convex/stats.ts
+++ b/convex/stats.ts
@@ -31,8 +31,7 @@ interface UsageLog {
   address: string;
   providerId?: Id<"providers">;
   model: string;
-  tokens: number;
-  latencyMs: number;
+  totalTokens: number;
   createdAt: number;
 }
 


### PR DESCRIPTION
## Summary
- update API typings for `recordInference`
- fix `UsageLog` interface in stats

## Testing
- `npm run lint` *(fails: Parameter 'q' implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_b_684c70d834a8832faebd2b046731a07c