### PR TITLE
Fix schema mismatch for legacy usage logs

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -104,10 +104,13 @@ export default defineSchema({
     address: v.string(),
     providerId: v.optional(v.id("providers")),
     model: v.string(),
-    intent: v.string(),
-    totalTokens: v.number(),
-    vcuCost: v.number(),
+    intent: v.optional(v.string()),
+    totalTokens: v.optional(v.number()),
+    vcuCost: v.optional(v.number()),
     createdAt: v.number(),
+    // Legacy field names from early deployments
+    tokens: v.optional(v.number()),
+    latencyMs: v.optional(v.number()),
   }).index("by_address", ["address"]),
 
   embeddings: defineTable({


### PR DESCRIPTION
## Summary
- support old usage logs that lack intent or rename token fields

## Testing
- `npm test` *(fails: cypress not found)*
- `npm run lint` *(fails: TS7006 errors)*

------
https://chatgpt.com/codex/tasks/task_b_684ce41dcf14832fb4b3d3eed6877e53