### PR TITLE
Improve random token generation

### DIFF
--- a/convex/apiKeys.ts
+++ b/convex/apiKeys.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { query, mutation, internalMutation } from "./_generated/server";
 import { Id } from "./_generated/dataModel";
 import { api } from "./_generated/api";
+import { randomBytes } from "crypto";
 
 // API Key types and limits according to specification
 const API_KEY_TYPES = {
@@ -16,9 +17,7 @@ type ApiKeyType = keyof typeof API_KEY_TYPES;
  */
 function generateApiKey(type: ApiKeyType): string {
   const prefix = API_KEY_TYPES[type].prefix;
-  const randomPart = Array.from({ length: 32 }, () => 
-    Math.random().toString(36).charAt(2)
-  ).join('');
+  const randomPart = randomBytes(16).toString('hex');
   return `${prefix}${randomPart}`;
 }
 

--- a/convex/crypto.ts
+++ b/convex/crypto.ts
@@ -1,4 +1,5 @@
 import { v } from "convex/values";
+import { randomBytes } from "crypto";
 
 // Secure encryption utilities for API keys and sensitive data
 const ENCRYPTION_KEY_LENGTH = 32; // 256-bit key
@@ -7,27 +8,11 @@ const SALT_LENGTH = 32; // 256-bit salt
 
 // Generate cryptographically secure random bytes
 function generateSecureRandom(length: number): Uint8Array {
-  // In Node.js environment, use crypto.randomBytes
   if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
     return crypto.getRandomValues(new Uint8Array(length));
   }
-  
-  // Enhanced fallback with better entropy sources
-  const bytes = new Uint8Array(length);
-  const now = Date.now();
-  const performance_now = typeof performance !== 'undefined' ? performance.now() : 0;
-  
-  for (let i = 0; i < length; i++) {
-    // Combine multiple entropy sources
-    const entropy1 = Math.random();
-    const entropy2 = (now + i) % 256;
-    const entropy3 = (performance_now * (i + 1)) % 256;
-    const entropy4 = (Math.random() * (i + 1) * now) % 256;
-    
-    // Mix entropy sources
-    bytes[i] = Math.floor((entropy1 * 256 + entropy2 + entropy3 + entropy4) % 256);
-  }
-  return bytes;
+
+  return randomBytes(length);
 }
 
 // Generate secure random string for tokens and keys

--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useAccount, useSignMessage } from 'wagmi';
 import { useQuery } from 'convex/react';
 import { api } from '../../convex/_generated/api';
+import { generateSecureToken } from '../../convex/crypto';
 import {
   Shield,
   Activity,
@@ -66,7 +67,7 @@ const AdminAuth: React.FC<{ onAuthenticated: (session: AdminSession) => void }> 
       
       // Create session token (1 hour expiry as per PRD)
       const session: AdminSession = {
-        token: `admin_${timestamp}_${Math.random().toString(36).substring(7)}`,
+        token: `admin_${timestamp}_${generateSecureToken(16)}`,
         expires: Date.now() + (60 * 60 * 1000), // 1 hour
         signature: signature as string
       };


### PR DESCRIPTION
## Summary
- use `crypto.randomBytes` when WebCrypto is unavailable
- rely on `crypto.randomBytes` for API key generation
- create admin session tokens with `generateSecureToken`

## Testing
- `npm run lint` *(fails: Invalid character in convex/router.ts)*

------
https://chatgpt.com/codex/tasks/task_b_6858ce0765d8832f871a0f1f8ae55994